### PR TITLE
Resolved issue with using provideplugin when using externals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -156,14 +156,16 @@ const externals = function() {
 };
 
 const plugins = function() {
-  let plugins = [
-    new webpack.ProvidePlugin({
-      $: 'jquery',
-      jQuery: 'jquery',
-      'window.jQuery': 'jquery',
-      'window.$': 'jquery'
-    })
-  ];
+  let plugins = [];
+  if (process.env.NODE_ENV === 'development') {
+    plugins = [ new webpack.ProvidePlugin({
+        $: 'jquery',
+        jQuery: 'jquery',
+        'window.jQuery': 'jquery',
+        'window.$': 'jquery'
+      })
+    ];
+  }
 
   return plugins;
 };


### PR DESCRIPTION
As the provideplugin seems to overrule the globals set from external js files, e.g. loading jQuery from a CDN