### PR TITLE
Addressed an issue with missing or negative timing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1130,7 +1130,7 @@
       }
     },
     "@iiif/iiif-av-component": {
-      "version": "github:Noterik/iiif-av-component#14cd0d8b8c42f0fe454c406b61f90c1a05dbc10e",
+      "version": "github:Noterik/iiif-av-component#c6f4b00e47470cb4a250457a8c83880270a361bd",
       "from": "github:Noterik/iiif-av-component#build2",
       "requires": {
         "@iiif/base-component": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@europeana/media-player",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "EUPL-1.2",
   "main": "dist/europeana-media-player.min.js",
   "author": {

--- a/src/components/player/index.js
+++ b/src/components/player/index.js
@@ -57,7 +57,7 @@ export default class Player {
     };
 
     //Check if the language is set, and if we have this present, otherwise default to English
-    if (language.length === 0 || languages.find(lang => lang.code === language) === undefined) {
+    if (language.length === 0 || languages.find(lang => lang.code === language) === undefined || i18n[language] === undefined) {
       language = 'en';
     } else {
       configuredLanguage = language;
@@ -237,7 +237,7 @@ export default class Player {
       let label = languages.find(lang => lang.iso === track.language);
       label = label && label.name ? label.name : track.language;
       return '<li class="subtitlemenu-option" data-language="' + track.language + '" tabindex="0">' + label + '</li>';
-    });
+    }).join('');
     menu += '</ul>';
 
     btnSubtitles.after(menu);

--- a/src/components/player/index.scss
+++ b/src/components/player/index.scss
@@ -495,6 +495,7 @@ $title-height: 54px;
 .iiif-av-component .loading-progress {
   background-color: #ccc;
   box-shadow: inset 0 -1px 0 0 rgba(255, 255, 255, 0.15), inset 0 1px 0 0 rgba(255, 255, 255, 0.15);
+  height: 4px;
   position: absolute;
 }
 


### PR DESCRIPTION
The iiif-av-component relied on a correct duration, however when not available or negative (due to incorrect timing in the manifest) this was causing the player not to work. A workaround has been made that in such cases the duration of the media item itself is taken.
Also addressed an issue with the player to play before the media was buffered.
Buffering in the .loading-progress class now has a height as it otherwise doesn't show up.
Finally fixed an issue with multiple languages in the subtitle menu and a comma appearing